### PR TITLE
Fix for supporting C++14 sized deallocation operator

### DIFF
--- a/Source/operators.cpp
+++ b/Source/operators.cpp
@@ -11,6 +11,8 @@ void * operator new (size_t, void * p) { return p ; }
 void * operator new[](size_t size) { return pvPortMalloc(size); }
 void operator delete(void* ptr) { vPortFree(ptr); }
 void operator delete[](void * ptr) { vPortFree(ptr); }
+void operator delete(void* ptr, size_t size) { vPortFree(ptr); }
+void operator delete[](void* ptr, size_t size) { vPortFree(ptr); }
 
 //int _gettimeofday(struct timeval *__p, void *__tz){return 0;}
 

--- a/openware-notes.txt
+++ b/openware-notes.txt
@@ -293,6 +293,3 @@ PE12 / pin 43 :
 
 -----------------------------------------------------------------
 
-Compiling with C++14 support with -std=gnu++14 can cause `operator delete(void*, size_t) undefined` errors.
-
------------------------------------------------------------------


### PR DESCRIPTION
It's a minor issue, but I felt like doing something with low practical value today.

This fixes error that was happening when building under C++14. I didn't change Makefiles themselves to use it, just confirmed that defining operator makes it work. It looks like building in C++14 mode made no changes to firmware code size, so GCC is likely generating the same code unless some newer language features are used.

Info about this in C++ standard is here: https://isocpp.org/files/papers/n3778.html

Size parameter is just a hint that allows writing more effective deallocation handlers, but it's often ignored. Since Freertos deallocator doesn't support such parameter, we can also ignore it (this seems to also be the case if using GCC stdlib)

I've added sized delete[] operator as well for completeness, but it doesn't seem to be required in our code yet.