### PR TITLE
Stack overflow handler is called from ISR

### DIFF
--- a/Source/ProgramManager.cpp
+++ b/Source/ProgramManager.cpp
@@ -678,9 +678,9 @@ extern "C" {
     (void) pxTask;
     /* Run time stack overflow checking is performed if
        configCHECK_FOR_STACK_OVERFLOW is defined to 1 or 2.  This hook
-       function is called if a stack overflow is detected. */
+       function is called from PendSV ISR if a stack overflow is detected. */
     error(PROGRAM_ERROR, "Stack overflow");
-    program.exitProgram(false);
+    program.exitProgram(true);
     HAL_Delay(5000);
     assert_param(0);
   }


### PR DESCRIPTION
I've ran into stack overflow in some new code I'm working on. The actual issue is not about SO itself, but the fact that it's calling     program.exitProgram(false) from PendSV ISR on context switch. Result is that assert in Freertos catches this situation, not sure what would happen on release version.

So changing vApplicationStackOverflowHook to call program.exitProgram(true) would be the obvious solution.

For reference, [Freertos docs](https://freertos.org/Stacks-and-stack-overflow-checking.html) and traceback below

```
vPortEnterCritical@0x080094fc (/home/antisvin/dev/rebeltech/OpenWare.daisy/DaisyPatch/Middlewares/Third_Party/FreeRTOS/Source/portable/GCC/ARM_CM4F/port.c:415)
xTaskGenericNotify@0x0800a184 (/home/antisvin/dev/rebeltech/OpenWare.daisy/DaisyPatch/Middlewares/Third_Party/FreeRTOS/Source/tasks.c:4723)
ProgramManager::notifyManager@0x08007244 (/home/antisvin/dev/rebeltech/OpenWare.daisy/Source/ProgramManager.cpp:574)
ProgramManager::exitProgram@0x080075fa (/home/antisvin/dev/rebeltech/OpenWare.daisy/Source/ProgramManager.cpp:695)
vApplicationStackOverflowHook@0x080075fa (/home/antisvin/dev/rebeltech/OpenWare.daisy/Source/ProgramManager.cpp:695)
vTaskSwitchContext@0x08009fb4 (/home/antisvin/dev/rebeltech/OpenWare.daisy/DaisyPatch/Middlewares/Third_Party/FreeRTOS/Source/tasks.c:2988)
PendSV_Handler@0x08009574 (/home/antisvin/dev/rebeltech/OpenWare.daisy/DaisyPatch/Middlewares/Third_Party/FreeRTOS/Source/portable/GCC/ARM_CM4F/port.c:435)
```