### PR TITLE
Force patch data refresh before loading

### DIFF
--- a/Source/ProgramManager.cpp
+++ b/Source/ProgramManager.cpp
@@ -611,8 +611,10 @@ void ProgramManager::loadDynamicProgram(void* address, uint32_t length){
 }
 
 void ProgramManager::loadProgram(uint8_t pid){
+  // We must always force loading patch definition, because it uses cached value that
+  // is also updated in other places
+  PatchDefinition* def = registry.getPatchDefinition(pid);
   if(patchindex != pid){
-    PatchDefinition* def = registry.getPatchDefinition(pid);
     if(def != NULL && def->getProgramVector() != NULL){
       patchdef = def;
       updateProgramIndex(pid);


### PR DESCRIPTION
I've ran into curious bug when working on Daisy UI. That part was copied from Magus parameter controller, so it's not something that was introduced by me (and I'm pretty sure I was seeing this issue on Magus before). Here's how to reproduce the issue:

1. Add at least 2 patches to storage

2. After reboot patch 1 is selected

3. Go to preset selection menu, select patch 1 again

4. See how patch 2 gets loaded and question your sanity

I've figured out why it's happening. ProgramManager.patchdef is a pointer that points to a static PatchDefinition object (likely to avoid memory allocation on every patch read). That static object itself gets overwritten when reading every patch details. When UI menu renders first page, second patch data is stored in object which patchdef pointer still addresses, but the loader function just assumes that it should read whatever patched points to if patch index was unchanged.

So without this change we will load patch which was last read if patch index is not changed. It may be better to change something to avoid potential similar bugs (i.e. use separate patch definition objects for last loaded patch and this cache object).