### PR TITLE
Develop branch won't build on devices with screen

### DIFF
--- a/Source/ProgramManager.cpp
+++ b/Source/ProgramManager.cpp
@@ -242,7 +242,13 @@ void onProgramReady(){
 #endif
 
   midi_rx.receive(); // push queued up MIDI messages through to patch
+#ifdef USE_ADC
+#ifdef USE_SCREEN
+  updateParameters(graphics.params.parameters, NOF_PARAMETERS, adc_values, NOF_ADC_VALUES);
+#else
   updateParameters(parameter_values, NOF_PARAMETERS, adc_values, NOF_ADC_VALUES);
+#endif
+#endif
   pv->buttons = button_values;
   if(pv->buttonChangedCallback != NULL && stateChanged.getState()){
     int bid = stateChanged.getFirstSetIndex();


### PR DESCRIPTION
Because of this:

```
./../Source/ProgramManager.cpp: In function 'void onProgramReady()':
./../Source/ProgramManager.cpp:245:20: error: 'parameter_values' was not declared in this scope; did you mean 'setParameterValues'?
  245 |   updateParameters(parameter_values, NOF_PARAMETERS, adc_values, NOF_ADC_VALUES);
      |                    ^~~~~~~~~~~~~~~~
      |                    setParameterValues
./../Source/ProgramManager.cpp:245:54: error: 'adc_values' was not declared in this scope
  245 |   updateParameters(parameter_values, NOF_PARAMETERS, adc_values, NOF_ADC_VALUES);
```

I've made a fix that at least allow building FW on devices with screen and no ADC. Will test ADC + Screen with a custom handler on Daisy after rebasing.

Another option would be to have a dedicated method in ParameterController template that would handle updates from ADC instead of this method for devices with screen. 