### PR TITLE
Fix build on Windows 10

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,9 @@ endif
 
 .PHONY: clean deploy-midiboot deploy-alchemist
 
+# To avoid problems on case insensitive filesystems, mark all targets named the same as a directory as phony
+.PHONY: midiboot tesseract alchemist wizard owlpedal quadfm player prism magus effectsbox noctua biosignals
+
 export OPENWARE CONFIG
 
 all: alchemist wizard magus tesseract prism effectsbox owlpedal player #quadfm owlboot ## build (almost) all targets


### PR DESCRIPTION
- There are many targets in the Makefile which have names that are the same as a directory, except the directory is capitalized. Eg Makefile target `magus` directory `Magus`. On Linux, this works fine.
- However I am building on "Ubuntu for Linux for Windows" on Windows 10. I am storing my OpenWare checkout in an ordinary NTFS directory. Ordinary NTFS is case insensitive.
- On a case insensitive filesystem, `make magus` will match the directory `Magus`. From the perspective of `make`, a directory is always up to date. So `make magus` does nothing 100% of the time.
- You can fix this by making the `magus` target (and all other targets that duplicate directory names) PHONY.