### PR TITLE
Defrag location fix

### DIFF
--- a/Hardware/owl1.ld
+++ b/Hardware/owl1.ld
@@ -163,6 +163,7 @@ SECTIONS
     PROVIDE (_FLASH_STORAGE_BEGIN = .);
   } >STORAGE
   _FLASH_STORAGE_END = ORIGIN(STORAGE) + LENGTH(STORAGE);
+  _FLASH_STORAGE_SIZE = LENGTH(STORAGE);
 
   /* Remove information from the standard libraries */
   /DISCARD/ :

--- a/Hardware/owl2.ld
+++ b/Hardware/owl2.ld
@@ -163,6 +163,7 @@ SECTIONS
     PROVIDE (_FLASH_STORAGE_BEGIN = .);
   } >STORAGE
   _FLASH_STORAGE_END = ORIGIN(STORAGE) + LENGTH(STORAGE);
+  _FLASH_STORAGE_SIZE = LENGTH(STORAGE);
 
   /* Remove information from the standard libraries */
   /DISCARD/ :

--- a/Source/PatchRegistry.cpp
+++ b/Source/PatchRegistry.cpp
@@ -68,9 +68,11 @@ void PatchRegistry::store(uint8_t index, uint8_t* data, size_t size){
   if(size < 4)
     return error(FLASH_ERROR, "Invalid resource size");
 #if USE_EXTERNAL_RAM
-  extern char _EXTRAM;
+  extern char _EXTRAM_END, _FLASH_STORAGE_SIZE;
   if(size > storage.getFreeSize())
-    storage.defrag((uint8_t*)&_EXTRAM, 1024*1024);
+    storage.defrag(
+      (uint8_t*)&_EXTRAM_END - (uint32_t)(&_FLASH_STORAGE_SIZE),
+      (uint32_t)(&_FLASH_STORAGE_SIZE));
 #endif
   uint32_t* magic = (uint32_t*)data;
   if(*magic == 0xDADAC0DE && index > 0 && index <= MAX_NUMBER_OF_PATCHES){


### PR DESCRIPTION
This fixes issue #11 

We only need 128k RAM for the incoming patch and 512k for copy of current storage. So we can fit everything on 1M/8M external RAM chip as long as this data is stored on opposite ends of RAM.