### PR TITLE
Don't show error when no patches are available

### DIFF
--- a/Source/PatchRegistry.cpp
+++ b/Source/PatchRegistry.cpp
@@ -127,6 +127,10 @@ unsigned int PatchRegistry::getNumberOfPatches(){
   return patchCount+1;
 }
 
+bool PatchRegistry::hasPatches(){
+  return patchCount > 0 || dynamicPatchDefinition != NULL;
+}
+
 PatchDefinition* PatchRegistry::getPatchDefinition(unsigned int index){
   PatchDefinition *def = NULL;
   if(index == 0)

--- a/Source/PatchRegistry.h
+++ b/Source/PatchRegistry.h
@@ -18,6 +18,7 @@ public:
   const char* getResourceName(unsigned int index);
   PatchDefinition* getPatchDefinition(unsigned int index);
   unsigned int getNumberOfPatches();
+  bool hasPatches();
   void registerPatch(PatchDefinition* def);
   void setDynamicPatchDefinition(PatchDefinition* def){
     dynamicPatchDefinition = def;

--- a/Source/ProgramManager.cpp
+++ b/Source/ProgramManager.cpp
@@ -528,7 +528,7 @@ void runManagerTask(void* p){
 				      (StackType_t*)PROGRAMSTACK, 
 				      &audioTaskBuffer);
       }
-      if(audioTask == NULL)
+      if(audioTask == NULL && registry.hasPatches())
 	error(PROGRAM_ERROR, "Failed to start program task");
     }
   }


### PR DESCRIPTION
We have a check that displays error when audio task isn't running, but this gives false impression that something is wrong with the device after erasing patch registry. So let's show it only there is any patch that should be running - either in registry or dynamically loaded.