### PR TITLE
Global brightness control is embrarassingly simple

### DIFF
--- a/Magus/Src/Magus.cpp
+++ b/Magus/Src/Magus.cpp
@@ -72,7 +72,7 @@ void setup(){
 
     // LEDs
     TLC5946_init(&TLC5946_SPI);
-    TLC5946_setRGB_DC(0, 0, 0); // Start with 0 brightness here, update from settings later
+    TLC5946_setAll_DC(0); // Start with 0 brightness here, update from settings later
     TLC5946_setAll(0x10, 0x10, 0x10);
 
     HAL_GPIO_WritePin(TLC_BLANK_GPIO_Port, TLC_BLANK_Pin, GPIO_PIN_RESET);
@@ -115,7 +115,7 @@ void setup(){
   owl.setup();
 
   // Update LEDs brighness from settings
-  TLC5946_setRGB_DC(settings.leds_brightness,settings.leds_brightness, settings.leds_brightness);
+  TLC5946_setAll_DC(settings.leds_brightness);
   TLC5946_Refresh_DC();
 
   // enable pull-up resistors to un-reset encoder

--- a/Source/HAL_TLC5946.c
+++ b/Source/HAL_TLC5946.c
@@ -7,9 +7,9 @@
 #define TLC_DEVICES 	3
 #endif
 
-#define TLC_DC_CHANNELS 16
-#define TLC_DC_BYTES    (TLC_DC_CHANNELS * 3 / 4)
-#define TLC_GS_BYTES    (TLC_DC_CHANNELS * 3 / 2)
+#define TLC_CHANNELS 16
+#define TLC_DC_BYTES    (TLC_CHANNELS * 3 / 4)
+#define TLC_GS_BYTES    (TLC_CHANNELS * 3 / 2)
 
 static uint8_t rgGSbuf[TLC_DEVICES*TLC_GS_BYTES+1];
 static uint8_t rgDCbuf[TLC_DEVICES*TLC_DC_BYTES+1] =
@@ -134,16 +134,16 @@ void TLC5946_setRGB(uint8_t LED_ID, uint16_t val_R, uint16_t val_G, uint16_t val
 
 void TLC5946_setRGB_DC(uint8_t val_R, uint8_t val_G, uint8_t val_B)
 {
-	TLC5946_SetOutput_DC_Many(rgDCbuf, TLC_DC_CHANNELS, val_R);
-	TLC5946_SetOutput_DC_Many(rgDCbuf + TLC_DC_BYTES, TLC_DC_CHANNELS, val_G);
-	TLC5946_SetOutput_DC_Many(rgDCbuf + TLC_DC_BYTES * 2, TLC_DC_CHANNELS, val_B);
+	TLC5946_SetOutput_DC_Many(rgDCbuf, TLC_CHANNELS, val_R);
+	TLC5946_SetOutput_DC_Many(rgDCbuf + TLC_DC_BYTES, TLC_CHANNELS, val_G);
+	TLC5946_SetOutput_DC_Many(rgDCbuf + TLC_DC_BYTES * 2, TLC_CHANNELS, val_B);
 	
 	TLC5946_Refresh_DC();
 }
 
 void TLC5946_setAll_DC(uint8_t value)
 {
-	TLC5946_SetOutput_DC_Many(rgDCbuf, TLC_DC_CHANNELS * TLC_DEVICES, value);
+	TLC5946_SetOutput_DC_Many(rgDCbuf, TLC_CHANNELS * TLC_DEVICES, value);
 	TLC5946_Refresh_DC();
 }
 

--- a/Source/HAL_TLC5946.c
+++ b/Source/HAL_TLC5946.c
@@ -155,7 +155,6 @@ void TLC5946_setAll(uint16_t val_R, uint16_t val_G, uint16_t val_B){
   }
 }
 
-
 //_____ Initialisaion _________________________________________________________________________________________________
 void TLC5946_init (SPI_HandleTypeDef *spiconfig)
 {

--- a/Source/HAL_TLC5946.c
+++ b/Source/HAL_TLC5946.c
@@ -3,10 +3,13 @@
 #include "main.h"
 
 // #define TLC_CONTINUOUS
+#ifndef TLC_DEVICES
 #define TLC_DEVICES 	3
+#endif
 
-#define TLC_GS_BYTES 24
-#define TLC_DC_BYTES 12
+#define TLC_DC_CHANNELS 16
+#define TLC_DC_BYTES    (TLC_DC_CHANNELS * 3 / 4)
+#define TLC_GS_BYTES    (TLC_DC_CHANNELS * 3 / 2)
 
 static uint8_t rgGSbuf[TLC_DEVICES*TLC_GS_BYTES+1];
 static uint8_t rgDCbuf[TLC_DEVICES*TLC_DC_BYTES+1] =
@@ -57,6 +60,19 @@ void TLC5946_SetOutput_DC(uint8_t ic, uint8_t led, uint8_t value)
   *data = (*data & ~mask) | ((value << pos) & mask);
 }
 
+// Set the same value on one or more TLC clips. This is not called outside of this file.
+static void TLC5946_SetOutput_DC_Many(uint8_t* data, uint8_t num_values, uint8_t value)
+{
+    uint8_t* last_data = data + num_values * 3 / 4;
+    uint8_t byte1 = value << 2 | value >> 4;
+    uint8_t byte2 = value << 4 | value >> 2;
+    uint8_t byte3 = value << 6 | value;
+	while (data < last_data) {
+		*data++ = byte1;
+		*data++ = byte2;
+		*data++ = byte3;
+	}
+}
 
 void TLC5946_TxINTCallback(void)
 {
@@ -116,14 +132,18 @@ void TLC5946_setRGB(uint8_t LED_ID, uint16_t val_R, uint16_t val_G, uint16_t val
 	TLC5946_SetOutput_GS(1, rgLED_B[LED_ID-1], val_B);
 }
 
-void TLC5946_setRGB_DC(uint16_t val_R, uint16_t val_G, uint16_t val_B)
+void TLC5946_setRGB_DC(uint8_t val_R, uint8_t val_G, uint8_t val_B)
 {
-	uint8_t x;
+	TLC5946_SetOutput_DC_Many(rgDCbuf, TLC_DC_CHANNELS, val_R);
+	TLC5946_SetOutput_DC_Many(rgDCbuf + TLC_DC_BYTES, TLC_DC_CHANNELS, val_G);
+	TLC5946_SetOutput_DC_Many(rgDCbuf + TLC_DC_BYTES * 2, TLC_DC_CHANNELS, val_B);
 	
-	for(x=0; x<16; x++)	{TLC5946_SetOutput_DC(0, x, val_R);}
-	for(x=0; x<16; x++)	{TLC5946_SetOutput_DC(2, x, val_G);}
-	for(x=0; x<16; x++)	{TLC5946_SetOutput_DC(1, x, val_B);}
-	
+	TLC5946_Refresh_DC();
+}
+
+void TLC5946_setAll_DC(uint8_t value)
+{
+	TLC5946_SetOutput_DC_Many(rgDCbuf, TLC_DC_CHANNELS * TLC_DEVICES, value);
 	TLC5946_Refresh_DC();
 }
 

--- a/Source/HAL_TLC5946.h
+++ b/Source/HAL_TLC5946.h
@@ -26,8 +26,9 @@ void TLC5946_Refresh_DC(void);
 void TLC5946_TxINTCallback(void);
 
 void TLC5946_setRGB(uint8_t LED_ID, uint16_t val_R, uint16_t val_G, uint16_t val_B);
-void TLC5946_setRGB_DC(uint16_t val_R, uint16_t val_G, uint16_t val_B);
+void TLC5946_setRGB_DC(uint8_t val_R, uint8_t val_G, uint8_t val_B);
 void TLC5946_setAll(uint16_t val_R, uint16_t val_G, uint16_t val_B);
+void TLC5946_setAll_DC(uint8_t value);
 
 #ifdef __cplusplus
 }

--- a/Source/MagusParameterController.hpp
+++ b/Source/MagusParameterController.hpp
@@ -882,7 +882,7 @@ public:
       break;
     case LEDS:
       selectedPid[1] = max(0, min(63, value));
-      TLC5946_setRGB_DC(selectedPid[1], selectedPid[1], selectedPid[1]);
+      TLC5946_setAll_DC(selectedPid[1]);
       TLC5946_Refresh_DC();      
       settings.leds_brightness = selectedPid[1];
       saveSettings = true;


### PR DESCRIPTION
Ok, we don't strictly have to use it, but setting DC for the whole chip is just to simple not to replace the old code. I've confirmed that new functions work as expected (setting brightness or per channel brightness).

Also 8 bit brightness is sufficient for this chip, so I've changed DC functions signature (was 16 bit like GS).
