### PR TITLE
Allow selecting global parameter with right encoder on Magus

### DIFF
--- a/Source/MagusParameterController.hpp
+++ b/Source/MagusParameterController.hpp
@@ -768,29 +768,32 @@ public:
       default:
         break;
       }
-    }else{
+    }
+    else{
       if(controlMode == EXIT){
-	displayMode = STANDARD;
-	sensitivitySelected = false;
-	if(saveSettings)
-	  settings.saveToFlash();
-      }else{
-	int16_t delta = value - encoders[1];
-	if(delta > 0 && controlMode+1 < NOF_CONTROL_MODES){
-	  setControlMode(controlMode+1);
-	}else if(delta < 0 && controlMode > 0){
-	  setControlMode(controlMode-1);
-	}
-	if (controlMode == CALIBRATE) {
-	  if (continueCalibration)
-	    updateCalibration();
-	  else
-	    calibrationConfirm = false;
-	}
-  else if (controlMode == DATA && resourceDeletePressed) {
-    resourceDeletePressed = false;
-  }
-	encoders[1] = value;
+        displayMode = STANDARD;
+        sensitivitySelected = false;
+        if(saveSettings)
+          settings.saveToFlash();
+      }
+      else{
+        int16_t delta = value - encoders[1];
+        if(delta > 0 && controlMode+1 < NOF_CONTROL_MODES){
+          setControlMode(controlMode+1);
+        }
+        else if(delta < 0 && controlMode > 0){
+          setControlMode(controlMode-1);
+        }
+        if (controlMode == CALIBRATE) {
+          if (continueCalibration)
+            updateCalibration();
+          else
+            calibrationConfirm = false;
+        }
+        else if (controlMode == DATA && resourceDeletePressed) {
+          resourceDeletePressed = false;
+        }
+        encoders[1] = value;
       }
     }
   }
@@ -996,18 +999,18 @@ public:
             if(delta > 0)
               selectBlockParameter(i, selectedPid[i]+1);
           }
-	else{
-	  if(encoders[i] != value){
-	    selectedBlock = i;
-	    encoders[i] = value;
-	    // We must update encoder value before calculating user value, otherwise
-	    // previous value would be displayed
-	    user[selectedPid[i]] = getEncoderValue(i);
-	  }
-	  if(displayMode == SELECTBLOCKPARAMETER && selectedBlock == i)
-	    displayMode = STANDARD;
-	}
-	encoders[i] = value;
+        else{
+          if(encoders[i] != value){
+            selectedBlock = i;
+            encoders[i] = value;
+            // We must update encoder value before calculating user value, otherwise
+            // previous value would be displayed
+            user[selectedPid[i]] = getEncoderValue(i);
+          }
+          if(displayMode == SELECTBLOCKPARAMETER && selectedBlock == i)
+            displayMode = STANDARD;
+        }
+        encoders[i] = value;
       }
       if(displayMode == STANDARD && getErrorStatus() && getErrorMessage() != NULL)
         displayMode = ERROR;    

--- a/Source/MagusParameterController.hpp
+++ b/Source/MagusParameterController.hpp
@@ -772,6 +772,7 @@ public:
     else{
       if(controlMode == EXIT){
         displayMode = STANDARD;
+        //selectedBlock = 0;
         sensitivitySelected = false;
         if(saveSettings)
           settings.saveToFlash();
@@ -928,6 +929,7 @@ public:
 
     // update encoder 1 top right
     int16_t value = data[2];
+    int16_t right_enc = encoders[1]; // Save old value for encoder scrolling in main menu
     if(displayMode == CONTROL){
       selectControlMode(value, pressed&0x3); // action if either left or right encoder pushed
       if(pressed&0x3c) // exit status mode if any other encoder is pressed
@@ -962,23 +964,38 @@ public:
         displayMode = SELECTGLOBALPARAMETER;
         int16_t delta = value - encoders[0];
         if(delta < 0) {
-          selectGlobalParameter(selectedPid[0]-1);
-        }
+          selectGlobalParameter(selectedPid[selectedBlock] - 1);
+          selectedBlock = 0;
+      }
         else {
           if(delta > 0) {              
-            selectGlobalParameter(selectedPid[0]+1);
+            selectGlobalParameter(selectedPid[selectedBlock] + 1);
+            selectedBlock = 0;
           }
-          selectedBlock = 0;
         }
       }
       else{
+        if (displayMode == STANDARD) {
+          // Quick selection of global parameter by right encoder - without popover menu
+          int16_t delta = data[2] - right_enc;
+          encoders[1] = data[2];
+          if(delta < 0) {
+            selectGlobalParameter(selectedPid[selectedBlock] - 1);
+            selectedBlock = 0;
+          }
+          else
+            if(delta > 0) {
+              selectGlobalParameter(selectedPid[selectedBlock] + 1);
+              selectedBlock = 0;
+            }
+        }
         if(encoders[0] != value){
-          selectedBlock = 0;
           encoders[0] = value;
           // We must update encoder value before calculating user value, otherwise
           // previous value would be displayed
           user[selectedPid[0]] = getEncoderValue(0);
         }
+
         if(displayMode == SELECTGLOBALPARAMETER)
           displayMode = STANDARD;
       }

--- a/Source/MagusParameterController.hpp
+++ b/Source/MagusParameterController.hpp
@@ -963,14 +963,14 @@ public:
         // TODO: add 'special' parameters: Volume, Freq, Gain, Gate
         displayMode = SELECTGLOBALPARAMETER;
         int16_t delta = value - encoders[0];
+        selectedPid[0] = selectedPid[selectedBlock];
+        selectedBlock = 0;
         if(delta < 0) {
           selectGlobalParameter(selectedPid[selectedBlock] - 1);
-          selectedBlock = 0;
       }
         else {
           if(delta > 0) {              
             selectGlobalParameter(selectedPid[selectedBlock] + 1);
-            selectedBlock = 0;
           }
         }
       }


### PR DESCRIPTION
So here's how it works now:

- global parameter can be set by selected block or right encoder
- using right encoder scrolls across all parameters and overtakes global parameter control from selected block
- using one of bottom encoders overtakes global parameter control from right encoder
- entering left encoder's menu uses parameter last selected by active block or globally
- "parameter control" here means changing active parameter by left encoder

This seems to improve navigation in patches with large amount of parameters. Also, this allows quick access to the 4 top CV channels that don't have a bound encoder. I think we'll be extending Magus UI to allow setting extra 20 params soon, so better control over extra params is a must for this.