### PR TITLE
OWL patch loading fixes

### DIFF
--- a/Source/device.h
+++ b/Source/device.h
@@ -3,7 +3,7 @@
 
 #include "hardware.h"
 
-#define FIRMWARE_VERSION "v21.2-rc3"
+#define FIRMWARE_VERSION "v21.2-rc4"
 
 #ifndef AUDIO_OUTPUT_GAIN
 #define AUDIO_OUTPUT_GAIN            112


### PR DESCRIPTION
Previously button bouncing prevented patch from loading.

Yellow color button won't work, removed.

Also, dead band calculation copied from OWL1 firmware was a bit incorrect.