### PR TITLE
feature/hw legacy id

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,12 @@
+21.2.1
+------
+
+* Change hardware ID for legacy devices to prevent parameter inversion
+
+Known Issues:
+* USB Host does not support reconnecting devices
+* USB Audio might 'click' due to synchronisation problems with host
+
 21.2.0
 ------
 
@@ -11,10 +20,6 @@
 * USB devices renamed OWL-MAGUS, OWL-WIZARD et c.
 * MIDI command to retrieve resource names and sizes
 * MIDI command to delete resources
-
-Known Issues:
-* USB Host does not support reconnecting devices
-* USB Audio might 'click' due to synchronisation problems with host
 
 
 21.1.0

--- a/OwlPedal/Inc/hardware.h
+++ b/OwlPedal/Inc/hardware.h
@@ -7,12 +7,12 @@
 #define HARDWARE_ID                  OWL_RACK_HARDWARE
 #define HARDWARE_VERSION             "OWL Rack"
 #elif defined OWL_MODULAR
-#define HARDWARE_ID                  OWL_MODULAR_HARDWARE
+#define HARDWARE_ID                  OWL_MODULAR_LEGACY_HARDWARE
 #define HARDWARE_VERSION             "OWL Modular"
 #define AUDIO_INPUT_GAIN             92
 #define AUDIO_OUTPUT_GAIN            121
 #elif defined OWL_PEDAL
-#define HARDWARE_ID                  OWL_PEDAL_HARDWARE
+#define HARDWARE_ID                  OWL_PEDAL_LEGACY_HARDWARE
 #define HARDWARE_VERSION             "OWL Pedal"
 #define AUDIO_INPUT_GAIN             108
 #define AUDIO_OUTPUT_GAIN            115

--- a/OwlPedal/Inc/hardware.h
+++ b/OwlPedal/Inc/hardware.h
@@ -7,12 +7,12 @@
 #define HARDWARE_ID                  OWL_RACK_HARDWARE
 #define HARDWARE_VERSION             "OWL Rack"
 #elif defined OWL_MODULAR
-#define HARDWARE_ID                  OWL_MODULAR_LEGACY_HARDWARE
+#define HARDWARE_ID                  OWL_MODULAR_HARDWARE
 #define HARDWARE_VERSION             "OWL Modular"
 #define AUDIO_INPUT_GAIN             92
 #define AUDIO_OUTPUT_GAIN            121
 #elif defined OWL_PEDAL
-#define HARDWARE_ID                  OWL_PEDAL_LEGACY_HARDWARE
+#define HARDWARE_ID                  OWL_PEDAL_HARDWARE
 #define HARDWARE_VERSION             "OWL Pedal"
 #define AUDIO_INPUT_GAIN             108
 #define AUDIO_OUTPUT_GAIN            115

--- a/Source/device.h
+++ b/Source/device.h
@@ -3,7 +3,7 @@
 
 #include "hardware.h"
 
-#define FIRMWARE_VERSION "v21.2"
+#define FIRMWARE_VERSION "v21.2.1"
 
 #ifndef AUDIO_OUTPUT_GAIN
 #define AUDIO_OUTPUT_GAIN            112

--- a/Source/hardware_ids.h
+++ b/Source/hardware_ids.h
@@ -1,8 +1,8 @@
 #ifndef __HARDWARE_IDS_H
 #define __HARDWARE_IDS_H
 
-#define OWL_PEDAL_HARDWARE          0x11
-#define OWL_MODULAR_HARDWARE        0x12
+#define OWL_PEDAL_LEGACY_HARDWARE   0x11
+#define OWL_MODULAR_LEGACY_HARDWARE 0x12
 #define OWL_RACK_HARDWARE           0x13
 #define PRISM_HARDWARE              0x14
 #define PLAYER_HARDWARE             0x15
@@ -17,8 +17,8 @@
 #define LICH_HARDWARE               0x1e
 #define WITCH_HARDWARE              0x1f
 #define GENIUS_HARDWARE             0x20
-#define OWL_PEDAL_LEGACY_HARDWARE   0x21
-#define OWL_MODULAR_LEGACY_HARDWARE 0x22
+#define OWL_PEDAL_HARDWARE          0x21
+#define OWL_MODULAR_HARDWARE        0x22
 #define OTHER_HARDWARE              0xf0
 
 #endif /* __HARDWARE_IDS_H */

--- a/Source/hardware_ids.h
+++ b/Source/hardware_ids.h
@@ -17,6 +17,8 @@
 #define LICH_HARDWARE               0x1e
 #define WITCH_HARDWARE              0x1f
 #define GENIUS_HARDWARE             0x20
+#define OWL_PEDAL_LEGACY_HARDWARE   0x21
+#define OWL_MODULAR_LEGACY_HARDWARE 0x22
 #define OTHER_HARDWARE              0xf0
 
 #endif /* __HARDWARE_IDS_H */


### PR DESCRIPTION
this is all that's needed for now to fix parameter inversion on OWL Modular, right @antisvin ?